### PR TITLE
feat: remove Node < 4 from official testing/support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 sudo: false
 language: node_js
 node_js:
-  - '0.10'
   - '4'
+  - '6'
   - 'node'
 after_success: npm run coverage

--- a/package.json
+++ b/package.json
@@ -32,10 +32,10 @@
   },
   "homepage": "https://github.com/nexdrew/which-module#readme",
   "devDependencies": {
-    "ava": "^0.17.0",
-    "coveralls": "^2.11.9",
-    "nyc": "^10.1.2",
-    "standard": "^8.0.0",
+    "ava": "^0.19.1",
+    "coveralls": "^2.13.1",
+    "nyc": "^10.3.0",
+    "standard": "^10.0.2",
     "standard-version": "^4.0.0"
   }
 }


### PR DESCRIPTION
BREAKING CHANGE: will no longer support Node 0.10 or 0.12, please update to Node 4+ or keep using which-module@1.0.0.

Note that the production code is still compatible with older versions of Node, but any future changes made will no longer be guaranteed to remain compatible.