### PR TITLE
chore: ignore package-lock.json

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 node_modules/
 .nyc_output/
+package-lock.json

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,5 +3,6 @@ language: node_js
 node_js:
   - '4'
   - '6'
+  - '8'
   - 'node'
 after_success: npm run coverage


### PR DESCRIPTION
Just gets in the way most of the time, especially for libraries.

Also test with Node 8.